### PR TITLE
Fix: Resolve AAAA record from hostname

### DIFF
--- a/LookingGlass.php
+++ b/LookingGlass.php
@@ -110,7 +110,7 @@ class LookingGlass
                 if ($type == 'ipv4' && isset(dns_get_record($host, DNS_A)[0]['ip'])) {
                     return $host;
                 }
-                if ($type == 'ipv6' && isset(dns_get_record($host, DNS_AAAA)[0]['ip'])) {
+                if ($type == 'ipv6' && isset(dns_get_record($host, DNS_AAAA)[0]['ipv6'])) {
                     return $host;
                 }
                 return '';


### PR DESCRIPTION
Fixes an issue with IPv6 tests (`ping6/mtr6/traceroute6`) when you use hostnames.

AAAA records were looked up correctly, but weren't extracted properly from the response given by `dns_get_record()` and would always fail if you specified a hostname.