### PR TITLE
Move root out of location context

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -29,12 +29,12 @@ http {
         listen [::]:80 default_server;
         server_name _;
 
+        root /var/www/html;
         location / {
             try_files $uri $uri/ /index.php$is_args$args;
         }
 
         location ~ \.php$ {
-            root /var/www/html;
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
             fastcgi_pass php-fpm:9000;
             fastcgi_index index.php;


### PR DESCRIPTION
We are also loading images, (like favicon.ico), these will also redirect to index.php.
Side effect, this causes the CSRF to be regenerated in the session.