### PR TITLE
Fix ipv6 issues

### DIFF
--- a/LookingGlass.php
+++ b/LookingGlass.php
@@ -167,7 +167,7 @@ class LookingGlass
      */
     public static function ping(string $host, int $count = 4): bool
     {
-        return self::procExecute('ping -c' . $count . ' -w15', $host);
+        return self::procExecute('ping -4 -c' . $count . ' -w15', $host);
     }
 
     /**

--- a/index.php
+++ b/index.php
@@ -46,7 +46,7 @@ if (!empty($_POST)) {
     }
 
     if (in_array($_POST['backendMethod'], ['ping6', 'mtr6', 'traceroute6'])) {
-        if (!LookingGlass::isValidIpv6($_POST['targetHost']) ||
+        if (!LookingGlass::isValidIpv6($_POST['targetHost']) &&
             !$targetHost = LookingGlass::isValidHost($_POST['targetHost'],LookingGlass::IPV6)
         ) {
             exitErrorMessage('No valid IPv6 provided.');


### PR DESCRIPTION
Discovered some ipv6 issues:

* Ping may default to ipv4 since `-4` is not specified
* Incorrect use of || instead of && for the isValidIpv6/isValidHost check