### PR TITLE
Fix TypeError reported in #12

### DIFF
--- a/LookingGlass.php
+++ b/LookingGlass.php
@@ -345,7 +345,7 @@ class LookingGlass
                 // kill remaining processes
                 foreach ($pids as $pid) {
                     if (is_numeric($pid)) {
-                        posix_kill($pid, 9);
+                        posix_kill((int) $pid, 9);
                     }
                 }
             }


### PR DESCRIPTION
Uncaught TypeError: posix_kill(): Argument #1 ($process_id) must be of type int, string given
Closes: #12