### PR TITLE
Fix #13 - add output scroll

### DIFF
--- a/index.php
+++ b/index.php
@@ -217,7 +217,7 @@ $templateData['csrfToken'] = $_SESSION[LookingGlass::SESSION_CSRF] = bin2hex(ran
                         <?php endif ?>
 
                         <div class="card card-body bg-light mt-4" style="display: none;" id="outputCard">
-                            <pre id="outputContent" style="overflow: hidden; white-space: pre; word-wrap: normal;"></pre>
+                            <pre id="outputContent" style="white-space: pre;word-wrap: normal;margin-bottom: 0;padding-bottom: 1rem;"></pre>
                         </div>
                     </form>
 


### PR DESCRIPTION
Removing the `overflow: hidden` to allow scrolling. 
Override the `margin-bottom` with 0 from bootstrap 
Add `padding-bottom` 1rem for some extra space between scollbar and content.

![image](https://user-images.githubusercontent.com/980978/222100717-35719d9a-e7f4-4e88-9a1a-2057f5e02f3c.png)
![image](https://user-images.githubusercontent.com/980978/222100759-eac3f2e5-18f2-4a50-be1a-12bbb275a7bc.png)

Closes #13
