### PR TITLE
Disable NGINX gzip & buffering

### DIFF
--- a/backend.php
+++ b/backend.php
@@ -19,6 +19,8 @@ use Hybula\LookingGlass;
 LookingGlass::validateConfig();
 LookingGlass::startSession();
 
+header('X-Accel-Buffering: no');
+
 if (isset($_SESSION[LookingGlass::SESSION_TARGET_HOST]) &&
     isset($_SESSION[LookingGlass::SESSION_TARGET_METHOD]) &&
     isset($_SESSION[LookingGlass::SESSION_CALL_BACKEND])


### PR DESCRIPTION
Shows the output while in-progress, instead of a few seconds delay.