### PR TITLE
Small Docker fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ made user-friendly for everyone to use. It allows you to execute network related
 - Root access.
 
 ### Installation
+#### Manual
 For this installation we will assume that we are working on AlmaLinux 8 or 9. Warning: This guide does not cover any security hardening or rate limiting.
 Note: These steps also work with AlmaLinux 9, but it will install PHP 8 instead of 7.
 
@@ -33,6 +34,17 @@ Note: These steps also work with AlmaLinux 9, but it will install PHP 8 instead 
 6. Upload the contents of the ZIP to /var/www/html/.
 7. Rename config.dist.php to config.php and adjust the settings.
 8. (Optional) You might want to enable SSL using LetsEncrypt, take a look at [acme.sh](https://github.com/acmesh-official/acme.sh).
+
+#### Docker
+For installation using Docker, follow these steps and run the commands on the target machine where the application should be installed:
+
+1. First, ensure Docker and Docker Compose are already installed.
+2. Clone this GitHub repository: `git clone https://github.com/hybula/lookingglass.git`.
+3. Change your current working directory to the freshly cloned repository.
+4. Currently, the Docker images are not hosted on an image repository, so you'll have to build them yourself with the following command: `docker compose build`.
+5. For production use, change the environment variables inside the `docker-compose.yml` file to the desired values. For testing purposes, the default values are fine.
+6. Create and start the containers: `docker compose up -d`.
+7. Afterward, the Looking Glass should be reachable from your web browser at `http://$your_server_ip/`!
 
 ### Upgrading
 Upgrading from a previous version is easy, simply overwrite your current installation with the new files. Then update your config.php accordingly, the script will automatically check for missing variables.

--- a/config.dist.php
+++ b/config.dist.php
@@ -81,5 +81,5 @@ const LG_SPEEDTEST_FILES = [
     '10G' => 'https://github.com/hybula/lookingglass/'
 ];
 
-// Define if you require visitors to agree with the Terms, set false to disable;
-const LG_TERMS = 'https://github.com/hybula/lookingglass/';
+// Define if you require visitors to agree with the Terms of Use. The value should be a link to the terms, or false to disable it completely.
+const LG_TERMS = false;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,16 @@ services:
       context: .
       dockerfile: docker/php-fpm/Dockerfile
     restart: unless-stopped
+    environment:
+      # For a better reference as to what these variables do, check out 'config.dist.php' or 'docker/php-fpm/src/config.php'.
+      # Please replace them with values that are relevant to your situation!
+      LOCATION: Location
+      FACILITY: Facility
+      FACILITY_URL: http://localhost/
+      IPV4_ADDRESS: 127.0.0.1
+      IPV6_ADDRESS: ::1
+      MAPS_QUERY: Amsterdam
+      # Uncomment to enable the custom block, which you can use to add something custom to the LG.
+      # ENABLE_CUSTOM_BLOCK: 'true'
+      # Uncomment if you require visitors to accept the Terms of Use; the value should be a link to the terms.
+      # LG_TERMS: http://localhost/

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -30,8 +30,13 @@ http {
         server_name _;
 
         root /var/www/html;
+
         location / {
             try_files $uri $uri/ /index.php$is_args$args;
+        }
+
+        location = /favicon.ico {
+            try_files $uri =204;
         }
 
         location ~ \.php$ {

--- a/docker/php-fpm/Dockerfile.dockerignore
+++ b/docker/php-fpm/Dockerfile.dockerignore
@@ -1,3 +1,3 @@
-Dockerfile
-Dockerfile.dockerignore
+docker/php-fpm/Dockerfile
+docker/php-fpm/Dockerfile.dockerignore
 .git

--- a/docker/php-fpm/src/config.php
+++ b/docker/php-fpm/src/config.php
@@ -81,5 +81,5 @@ const LG_SPEEDTEST_FILES = [
     '10G' => 'https://github.com/hybula/lookingglass/'
 ];
 
-// Define if you require visitors to agree with the Terms, set false to disable;
+// Define if you require visitors to agree with the Terms of Use. The value should be a link to the terms, or false to disable it completely.
 define('LG_TERMS', getenv('LG_TERMS') ?: false);

--- a/docker/php-fpm/src/config.php
+++ b/docker/php-fpm/src/config.php
@@ -82,4 +82,4 @@ const LG_SPEEDTEST_FILES = [
 ];
 
 // Define if you require visitors to agree with the Terms, set false to disable;
-define('LG_TERMS', getenv('LG_TERMS') ?: 'https://github.com/hybula/lookingglass/');
+define('LG_TERMS', getenv('LG_TERMS') ?: false);


### PR DESCRIPTION
This PR contains some small fixes for the Docker container(s) that I noticed:
- Prevent requests for `/favicon.ico` from being sent to PHP-FPM, which fixes an error regarding an invalid CSRF token.
- Currently, the optional Terms of Use feature thingy is always turned on, even if the corresponding `LG_TERMS` environment variable is not defined. This has been fixed, so that if this variable is not defined, it is not shown.
- I have added the available environment variables with examples to the `docker-compose.yml`, and commented out the optional ones that probably shouldn't be turned on by default.
- Fixes the paths to the files currently listed in the PHP-FPM Docker image's `.dockerignore` file; the build context of this image is set to the root of the repository, which means that any paths in the `.dockerignore` file should use this directory as the base as well.