### PR TITLE
Add environment variables to toggle different blocks in Docker container, fix constant typo

### DIFF
--- a/LookingGlass.php
+++ b/LookingGlass.php
@@ -62,8 +62,8 @@ class LookingGlass
         if (!defined('LG_BLOCK_NETWORK')) {
             die('LG_BLOCK_NETWORK not found in config.php');
         }
-        if (!defined('LG_BLOCK_LOOKINGGLAS')) {
-            die('LG_BLOCK_LOOKINGGLAS not found in config.php');
+        if (!defined('LG_BLOCK_LOOKINGGLASS')) {
+            die('LG_BLOCK_LOOKINGGLASS not found in config.php');
         }
         if (!defined('LG_BLOCK_SPEEDTEST')) {
             die('LG_BLOCK_SPEEDTEST not found in config.php');

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -44,7 +44,7 @@ $templateData           = [
     'logo_data_dark'                => LG_LOGO_DARK,
     //
     'block_network'            => LG_BLOCK_NETWORK,
-    'block_lookingglas'        => LG_BLOCK_LOOKINGGLAS,
+    'block_lookingglass'       => LG_BLOCK_LOOKINGGLASS,
     'block_speedtest'          => LG_BLOCK_SPEEDTEST,
     'block_custom'             => LG_BLOCK_CUSTOM,
     'custom_html'              => '',

--- a/config.dist.php
+++ b/config.dist.php
@@ -24,7 +24,7 @@ const LG_CUSTOM_HEAD = false;
 
 // Enable or disable blocks/parts of the LG, set false to hide a part;
 const LG_BLOCK_NETWORK = true;
-const LG_BLOCK_LOOKINGGLAS = true;
+const LG_BLOCK_LOOKINGGLASS = true;
 const LG_BLOCK_SPEEDTEST = true;
 // This enables the custom block, which you can use to add something custom to the LG;
 const LG_BLOCK_CUSTOM = false;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,10 @@ services:
       IPV4_ADDRESS: 127.0.0.1
       IPV6_ADDRESS: ::1
       MAPS_QUERY: Amsterdam
+      # Pass these variables with any arbitrary value to disable the respective block.
+      # DISABLE_BLOCK_NETWORK: 'true'
+      # DISABLE_BLOCK_LOOKINGGLASS: 'true'
+      # DISABLE_BLOCK_SPEEDTEST: 'true'
       # Uncomment to enable the custom block, which you can use to add something custom to the LG.
       # ENABLE_CUSTOM_BLOCK: 'true'
       # Uncomment if you require visitors to accept the Terms of Use; the value should be a link to the terms.

--- a/docker/php-fpm/src/config.php
+++ b/docker/php-fpm/src/config.php
@@ -22,13 +22,12 @@ const LG_CSS_OVERRIDES = false;
 // Define <head> content, this could be JS, CSS or meta tags;
 const LG_CUSTOM_HEAD = false;
 
-// Enable or disable blocks/parts of the LG, set false to hide a part;
-const LG_BLOCK_NETWORK = true;
-const LG_BLOCK_LOOKINGGLAS = true;
-const LG_BLOCK_SPEEDTEST = true;
-const LG_BLOCK_LOOKINGGLASS = true;
+// Enable or disable blocks/parts of the LG, pass these environment variables with any value to disable them;
+define('LG_BLOCK_NETWORK', !isset($_ENV['DISABLE_BLOCK_NETWORK']));
+define('LG_BLOCK_LOOKINGGLASS', !isset($_ENV['DISABLE_BLOCK_LOOKINGGLASS']));
+define('LG_BLOCK_SPEEDTEST', !isset($_ENV['DISABLE_BLOCK_SPEEDTEST']));
 // This enables the custom block, which you can use to add something custom to the LG;
-define('LG_BLOCK_CUSTOM', getenv('ENABLE_CUSTOM_BLOCK') !== false);
+define('LG_BLOCK_CUSTOM', isset($_ENV['ENABLE_CUSTOM_BLOCK']));
 
 // Define a file here which will be used to display the custom block, can be PHP too which outputs HTML;
 const LG_CUSTOM_HTML = __DIR__.'/custom.html.php';

--- a/docker/php-fpm/src/config.php
+++ b/docker/php-fpm/src/config.php
@@ -26,6 +26,7 @@ const LG_CUSTOM_HEAD = false;
 const LG_BLOCK_NETWORK = true;
 const LG_BLOCK_LOOKINGGLAS = true;
 const LG_BLOCK_SPEEDTEST = true;
+const LG_BLOCK_LOOKINGGLASS = true;
 // This enables the custom block, which you can use to add something custom to the LG;
 define('LG_BLOCK_CUSTOM', getenv('ENABLE_CUSTOM_BLOCK') !== false);
 

--- a/index.php
+++ b/index.php
@@ -194,7 +194,7 @@ $templateData['csrfToken'] = $_SESSION[LookingGlass::SESSION_CSRF] = bin2hex(ran
         </div>
         <?php endif ?>
 
-        <?php if (LG_BLOCK_LOOKINGGLAS): ?>
+        <?php if (LG_BLOCK_LOOKINGGLASS): ?>
         <div class="row pb-5">
             <div class="card shadow-lg">
                 <div class="card-body p-3">

--- a/index.php
+++ b/index.php
@@ -70,19 +70,23 @@ if (isset($_SESSION[LookingGlass::SESSION_ERROR_MESSAGE])) {
 }
 
 if (LG_BLOCK_CUSTOM) {
-    include LG_CUSTOM_PHP;
+    if (defined('LG_CUSTOM_PHP') && file_exists(LG_CUSTOM_PHP)) {
+        include LG_CUSTOM_PHP;
+    }
 
-    ob_start();
-    include LG_CUSTOM_HTML;
-    $templateData['custom_html'] = ob_get_clean();
+    if (defined('LG_CUSTOM_HTML') && file_exists(LG_CUSTOM_HTML)) {
+        ob_start();
+        include LG_CUSTOM_HTML;
+        $templateData['custom_html'] = ob_get_clean();
+    }
 
-    if (defined('LG_CUSTOM_HEADER_PHP')) {
+    if (defined('LG_CUSTOM_HEADER_PHP') && file_exists(LG_CUSTOM_HEADER_PHP)) {
         ob_start();
         include LG_CUSTOM_HEADER_PHP;
         $templateData['custom_header'] = ob_get_clean();
     }
 
-    if (defined('LG_CUSTOM_FOOTER_PHP')) {
+    if (defined('LG_CUSTOM_FOOTER_PHP') && file_exists(LG_CUSTOM_FOOTER_PHP)) {
         ob_start();
         include LG_CUSTOM_FOOTER_PHP;
         $templateData['custom_footer'] = ob_get_clean();


### PR DESCRIPTION
Related to https://github.com/hybula/lookingglass/issues/35.

This PR allows you to disable the 'Network', 'Looking Glass' and 'Speedtest' blocks through environment variables in the Docker container.
These have to be explicitly passed in order to disable these blocks, contrary to the custom block environment variable, which has to be explicitly passed to _enable_ it. This is 1) to keep forward compatibility so these blocks won't suddenly be gone after someone updates their container without adding these environment variables and 2) most people would probably want to have these blocks enabled, so enabling them by default seems good.

EDIT: I've also added some robuster checking around the custom block constants, namely by only including the files if both the constants are defined _and_ the passed files actually exist.