### PR TITLE
Fix ss command on newer versions of iproute2

### DIFF
--- a/LookingGlass.php
+++ b/LookingGlass.php
@@ -439,7 +439,7 @@ class LookingGlass
             // RHEL based systems;
             $ssPath = '/usr/sbin/ss';
         }
-        $lines = shell_exec("$ssPath -Hnti state established");
+        $lines = shell_exec("$ssPath -Hintp state established");
         $ss = [];
         $i = 0;
         $j = 0;


### PR DESCRIPTION
The iproute2 package starting in version 6.7.0 changed the way the `ss` command outputs internal TCP information via the `-i/--info` option which LookingGlass uses to display latency information.

In prior versions the flags: `-Hint` would show internal TCP information. However starting in version 6.7.0 an additional flag `-p/--processes` needs to be passed in to get the same information.

The changes were committed upstream in
https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/commit/misc/ss.c?id=87d804ca0854b09c07872e9fd6036bf5d3e0cc85 and effects all versions of iproute2 6.7.0 and later.

Old versions continue to work with and without the `-p/--processes` flag. In my limited testing it appears adding extra flag is backwards compatible and should not break anything.