### PR TITLE
Docker Fixes, iPerf3 Feature Completion, Minor PHP Code Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,14 @@ made user-friendly for everyone to use. It allows you to execute network related
 For this installation we will assume that we are working on AlmaLinux 8 or 9. Warning: This guide does not cover any security hardening or rate limiting.
 Note: These steps also work with AlmaLinux 9, but it will install PHP 8 instead of 7.
 
-1. Install the required network tools: `dnf install mtr traceroute iperf3 -y`.
+1. Install the required network tools: `dnf install mtr traceroute -y`.
 2. Install the web server with PHP (by default it will install 7.2 on RHEL 8): `dnf install httpd mod_ssl php php-posix -y`.
 3. Enable and start Apache/PHP-FPM: `systemctl enable --now httpd && systemctl enable --now php-fpm`.
 4. Let's help MTR to work, execute the following command: `ln -s /usr/sbin/mtr /usr/bin/mtr` and also mtr helper called mtr-packet: `ln -s /usr/sbin/mtr-packet /usr/bin/mtr-packet`.
 5. You *must* configure SELinux before this all works, or you can disable SELinux using `setenforce 0` and possibly make it permanent: `nano /etc/selinux/config` change to `SELINUX=disabled`.
-6. Launch iPerf3 as a daemon: `iperf3 -sD -p 5201`.
-7. (Optional) You might want to add a systemd unit file for iPerf3, so it automatically starts when the system boots up.
-8. Upload the contents of the ZIP to /var/www/html/.
-9. Rename config.dist.php to config.php and adjust the settings.
-10. (Optional) You might want to enable SSL using LetsEncrypt, take a look at [acme.sh](https://github.com/acmesh-official/acme.sh).
+6. Upload the contents of the ZIP to /var/www/html/.
+7. Rename config.dist.php to config.php and adjust the settings.
+8. (Optional) You might want to enable SSL using LetsEncrypt, take a look at [acme.sh](https://github.com/acmesh-official/acme.sh).
 
 #### Docker
 For installation using Docker, follow these steps and run the commands on the target machine where the application should be installed:
@@ -48,6 +46,24 @@ For installation using Docker, follow these steps and run the commands on the ta
 5. For production use, change the environment variables inside the `docker-compose.yml` file to the desired values. For testing purposes, the default values are fine.
 6. Create and start the containers: `docker compose up -d`.
 7. Afterward, the Looking Glass should be reachable from your web browser at `http://$your_server_ip/`!
+
+### iPerf3 Installation (Optional)
+> It is recommended to install iPerf3 on a different server from your looking glass to avoid network congestion.
+
+#### Manual
+Again, we will assume that we are working on AlmaLinux 8 or 9.
+1. Install iPerf3: `dnf install iperf3 -y`
+2. Launch iPerf3 as a daemon: `iperf3 -sD -p 5201`.
+3. (Optional) You might want to add a systemd unit file for iPerf3, so it automatically starts when the system boots up.
+4. Locate the two lines containing `LG_SPEEDTEST_CMD_INCOMING` and `LG_SPEEDTEST_CMD_OUTGOING` respectively in `config.php`.
+5. Change `hostname` in these lines to the IPv4 address of your iPerf3 server.
+
+#### Docker
+1. Uncomment the section for `iperf3` in `docker-compose.yml` if you want iPerf3 and the looking glass to be on the same server.
+Otherwise, please copy the `iperf3` section and save it as `docker-compose.yml` on another server with Docker and Docker Compose installed.
+2. Start the iPerf3 container: `docker compose up -d`.
+3. Locate the two lines containing `LG_SPEEDTEST_CMD_INCOMING` and `LG_SPEEDTEST_CMD_OUTGOING` respectively in `docker/php-fpm/src/config.php`.
+5. Change `hostname` in these lines to the IPv4 address of your iPerf3 server.
 
 ### Upgrading
 Upgrading from a previous version is easy, simply overwrite your current installation with the new files. Then update your config.php accordingly, the script will automatically check for missing variables.

--- a/README.md
+++ b/README.md
@@ -27,14 +27,16 @@ made user-friendly for everyone to use. It allows you to execute network related
 For this installation we will assume that we are working on AlmaLinux 8 or 9. Warning: This guide does not cover any security hardening or rate limiting.
 Note: These steps also work with AlmaLinux 9, but it will install PHP 8 instead of 7.
 
-1. Install the required network tools: `dnf install mtr traceroute -y`.
+1. Install the required network tools: `dnf install mtr traceroute iperf3 -y`.
 2. Install the web server with PHP (by default it will install 7.2 on RHEL 8): `dnf install httpd mod_ssl php php-posix -y`.
-3. Enable and start Apache/PHP-FPM: `systemctl enable httpd; systemctl enable php-fpm` and `systemctl start httpd; systemctl start php-fpm`.
+3. Enable and start Apache/PHP-FPM: `systemctl enable --now httpd && systemctl enable --now php-fpm`.
 4. Let's help MTR to work, execute the following command: `ln -s /usr/sbin/mtr /usr/bin/mtr` and also mtr helper called mtr-packet: `ln -s /usr/sbin/mtr-packet /usr/bin/mtr-packet`.
 5. You *must* configure SELinux before this all works, or you can disable SELinux using `setenforce 0` and possibly make it permanent: `nano /etc/selinux/config` change to `SELINUX=disabled`.
-6. Upload the contents of the ZIP to /var/www/html/.
-7. Rename config.dist.php to config.php and adjust the settings.
-8. (Optional) You might want to enable SSL using LetsEncrypt, take a look at [acme.sh](https://github.com/acmesh-official/acme.sh).
+6. Launch iPerf3 as a daemon: `iperf3 -sD -p 5201`.
+7. (Optional) You might want to add a systemd unit file for iPerf3, so it automatically starts when the system boots up.
+8. Upload the contents of the ZIP to /var/www/html/.
+9. Rename config.dist.php to config.php and adjust the settings.
+10. (Optional) You might want to enable SSL using LetsEncrypt, take a look at [acme.sh](https://github.com/acmesh-official/acme.sh).
 
 #### Docker
 For installation using Docker, follow these steps and run the commands on the target machine where the application should be installed:

--- a/config.dist.php
+++ b/config.dist.php
@@ -63,12 +63,11 @@ const LG_METHODS = [
 ];
 
 // Define other looking glasses, this is useful if you have multiple networks and looking glasses;
-/* const LG_LOCATIONS = [
+const LG_LOCATIONS = [
     'Location A' => 'https://github.com/hybula/lookingglass/',
     'Location B' => 'https://github.com/hybula/lookingglass/',
     'Location C' => 'https://github.com/hybula/lookingglass/',
-]; */
-const LG_LOCATIONS = [];
+];
 
 // Enable the iPerf info inside the speedtest block, set to false to disable;
 const LG_SPEEDTEST_IPERF = true;
@@ -81,12 +80,11 @@ const LG_SPEEDTEST_LABEL_OUTGOING = 'iPerf3 Outgoing';
 // Define the command to use to test outgoing speed using iPerf, preferable iPerf3;
 const LG_SPEEDTEST_CMD_OUTGOING = 'iperf3 -4 -c hostname -p 5201 -P 4 -R';
 // Define speedtest files with URLs to the actual files;
-/* const LG_SPEEDTEST_FILES = [
+const LG_SPEEDTEST_FILES = [
     '100M' => 'https://github.com/hybula/lookingglass/',
     '1G' => 'https://github.com/hybula/lookingglass/',
     '10G' => 'https://github.com/hybula/lookingglass/'
-]; */
-const LG_SPEEDTEST_FILES = [];
+];
 
 // Define if you require visitors to agree with the Terms of Use. The value should be a link to the terms, or false to disable it completely.
 const LG_TERMS = false;

--- a/config.dist.php
+++ b/config.dist.php
@@ -15,7 +15,7 @@ const LG_LOGO_URL = 'https://github.com/hybula/lookingglass/';
 const LG_THEME = 'auto';
 
 // Enable the latency check feature;
-const LG_CHECK_LATENCY = false;
+const LG_CHECK_LATENCY = true;
 
 // Define a custom CSS file which can be used to style the LG, set false to disable, else point to the CSS file;
 const LG_CSS_OVERRIDES = false;
@@ -63,28 +63,30 @@ const LG_METHODS = [
 ];
 
 // Define other looking glasses, this is useful if you have multiple networks and looking glasses;
-const LG_LOCATIONS = [
+/* const LG_LOCATIONS = [
     'Location A' => 'https://github.com/hybula/lookingglass/',
     'Location B' => 'https://github.com/hybula/lookingglass/',
     'Location C' => 'https://github.com/hybula/lookingglass/',
-];
+]; */
+const LG_LOCATIONS = [];
 
 // Enable the iPerf info inside the speedtest block, set to false to disable;
 const LG_SPEEDTEST_IPERF = true;
 // Define the label of an incoming iPerf test;
 const LG_SPEEDTEST_LABEL_INCOMING = 'iPerf3 Incoming';
 // Define the command to use to test incoming speed using iPerf, preferable iPerf3;
-const LG_SPEEDTEST_CMD_INCOMING = 'iperf3 -4 -c hostname -p 5201 -P 4';
+const LG_SPEEDTEST_CMD_INCOMING = 'iperf3 -4 -c ' . LG_IPV4 . ' -p 5201 -P 4';
 // Define the label of an outgoing iPerf test;
 const LG_SPEEDTEST_LABEL_OUTGOING = 'iPerf3 Outgoing';
 // Define the command to use to test outgoing speed using iPerf, preferable iPerf3;
-const LG_SPEEDTEST_CMD_OUTGOING = 'iperf3 -4 -c hostname -p 5201 -P 4 -R';
+const LG_SPEEDTEST_CMD_OUTGOING = 'iperf3 -4 -c ' . LG_IPV4 . ' -p 5201 -P 4 -R';
 // Define speedtest files with URLs to the actual files;
-const LG_SPEEDTEST_FILES = [
+/* const LG_SPEEDTEST_FILES = [
     '100M' => 'https://github.com/hybula/lookingglass/',
     '1G' => 'https://github.com/hybula/lookingglass/',
     '10G' => 'https://github.com/hybula/lookingglass/'
-];
+]; */
+const LG_SPEEDTEST_FILES = [];
 
 // Define if you require visitors to agree with the Terms of Use. The value should be a link to the terms, or false to disable it completely.
 const LG_TERMS = false;

--- a/config.dist.php
+++ b/config.dist.php
@@ -75,11 +75,11 @@ const LG_SPEEDTEST_IPERF = true;
 // Define the label of an incoming iPerf test;
 const LG_SPEEDTEST_LABEL_INCOMING = 'iPerf3 Incoming';
 // Define the command to use to test incoming speed using iPerf, preferable iPerf3;
-const LG_SPEEDTEST_CMD_INCOMING = 'iperf3 -4 -c ' . LG_IPV4 . ' -p 5201 -P 4';
+const LG_SPEEDTEST_CMD_INCOMING = 'iperf3 -4 -c hostname -p 5201 -P 4';
 // Define the label of an outgoing iPerf test;
 const LG_SPEEDTEST_LABEL_OUTGOING = 'iPerf3 Outgoing';
 // Define the command to use to test outgoing speed using iPerf, preferable iPerf3;
-const LG_SPEEDTEST_CMD_OUTGOING = 'iperf3 -4 -c ' . LG_IPV4 . ' -p 5201 -P 4 -R';
+const LG_SPEEDTEST_CMD_OUTGOING = 'iperf3 -4 -c hostname -p 5201 -P 4 -R';
 // Define speedtest files with URLs to the actual files;
 /* const LG_SPEEDTEST_FILES = [
     '100M' => 'https://github.com/hybula/lookingglass/',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,11 +34,11 @@ services:
       # Uncomment if you require visitors to accept the Terms of Use; the value should be a link to the terms.
       # LG_TERMS: http://localhost/
 
-  iperf3:
-    image: networkstatic/iperf3:latest
-    container_name: lg-iperf3
-    network_mode: host
-    command: -s
-    tty: true
-    stdin_open: true
-    restart: unless-stopped
+  # iperf3:
+  #   image: networkstatic/iperf3:latest
+  #   container_name: lg-iperf3
+  #   network_mode: host
+  #   command: -s
+  #   tty: true
+  #   stdin_open: true
+  #   restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,11 @@
-version: "3.8"
-
 services:
   nginx:
     image: hybula/lookingglass-nginx:1
     container_name: lg-nginx
     build:
-      context: docker/nginx
-      dockerfile: Dockerfile
-    ports:
-      - "80:80"
+      context: .
+      dockerfile: docker/nginx/Dockerfile
+    network_mode: host
     restart: unless-stopped
 
   php-fpm:
@@ -17,6 +14,7 @@ services:
     build:
       context: .
       dockerfile: docker/php-fpm/Dockerfile
+    network_mode: host
     restart: unless-stopped
     environment:
       # For a better reference as to what these variables do, check out 'config.dist.php' or 'docker/php-fpm/src/config.php'.
@@ -39,8 +37,7 @@ services:
   iperf3:
     image: networkstatic/iperf3:latest
     container_name: lg-iperf3
-    ports:
-      - "5201:5201"
+    network_mode: host
     command: -s
     tty: true
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.8"
 services:
   nginx:
     image: hybula/lookingglass-nginx:1
+    container_name: lg-nginx
     build:
       context: docker/nginx
       dockerfile: Dockerfile
@@ -12,6 +13,7 @@ services:
 
   php-fpm:
     image: hybula/lookingglass-php:1
+    container_name: lg-php
     build:
       context: .
       dockerfile: docker/php-fpm/Dockerfile
@@ -33,3 +35,13 @@ services:
       # ENABLE_CUSTOM_BLOCK: 'true'
       # Uncomment if you require visitors to accept the Terms of Use; the value should be a link to the terms.
       # LG_TERMS: http://localhost/
+
+  iperf3:
+    image: networkstatic/iperf3:latest
+    container_name: lg-iperf3
+    ports:
+      - "5201:5201"
+    command: -s
+    tty: true
+    stdin_open: true
+    restart: unless-stopped

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,3 +1,3 @@
 FROM nginx:mainline-alpine
 
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY docker/nginx/nginx.conf /etc/nginx/nginx.conf

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -41,7 +41,7 @@ http {
 
         location ~ \.php$ {
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
-            fastcgi_pass php-fpm:9000;
+            fastcgi_pass localhost:9000;
             fastcgi_index index.php;
             include fastcgi.conf;
             fastcgi_buffering on;

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.1-fpm-bullseye
 
 RUN apt-get update && \
-    apt-get --no-install-recommends -y install iputils-ping mtr traceroute && \
+    apt-get --no-install-recommends -y install iputils-ping mtr traceroute iproute2 && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /var/www/html

--- a/docker/php-fpm/src/config.php
+++ b/docker/php-fpm/src/config.php
@@ -63,12 +63,11 @@ const LG_METHODS = [
 ];
 
 // Define other looking glasses, this is useful if you have multiple networks and looking glasses;
-/* const LG_LOCATIONS = [
+const LG_LOCATIONS = [
     'Location A' => 'https://github.com/hybula/lookingglass/',
     'Location B' => 'https://github.com/hybula/lookingglass/',
     'Location C' => 'https://github.com/hybula/lookingglass/',
-]; */
-const LG_LOCATIONS = [];
+];
 
 // Enable the iPerf info inside the speedtest block, set to false to disable;
 const LG_SPEEDTEST_IPERF = true;
@@ -81,12 +80,11 @@ const LG_SPEEDTEST_LABEL_OUTGOING = 'iPerf3 Outgoing';
 // Define the command to use to test outgoing speed using iPerf, preferable iPerf3;
 const LG_SPEEDTEST_CMD_OUTGOING = 'iperf3 -4 -c hostname -p 5201 -P 4 -R';
 // Define speedtest files with URLs to the actual files;
-/* const LG_SPEEDTEST_FILES = [
+const LG_SPEEDTEST_FILES = [
     '100M' => 'https://github.com/hybula/lookingglass/',
     '1G' => 'https://github.com/hybula/lookingglass/',
     '10G' => 'https://github.com/hybula/lookingglass/'
-]; */
-const LG_SPEEDTEST_FILES = [];
+];
 
 // Define if you require visitors to agree with the Terms of Use. The value should be a link to the terms, or false to disable it completely.
 define('LG_TERMS', getenv('LG_TERMS') ?: false);

--- a/docker/php-fpm/src/config.php
+++ b/docker/php-fpm/src/config.php
@@ -15,7 +15,7 @@ const LG_LOGO_URL = 'https://github.com/hybula/lookingglass/';
 const LG_THEME = 'auto';
 
 // Enable the latency check feature;
-const LG_CHECK_LATENCY = false;
+const LG_CHECK_LATENCY = true;
 
 // Define a custom CSS file which can be used to style the LG, set false to disable, else point to the CSS file;
 const LG_CSS_OVERRIDES = false;
@@ -63,28 +63,30 @@ const LG_METHODS = [
 ];
 
 // Define other looking glasses, this is useful if you have multiple networks and looking glasses;
-const LG_LOCATIONS = [
+/* const LG_LOCATIONS = [
     'Location A' => 'https://github.com/hybula/lookingglass/',
     'Location B' => 'https://github.com/hybula/lookingglass/',
     'Location C' => 'https://github.com/hybula/lookingglass/',
-];
+]; */
+const LG_LOCATIONS = [];
 
 // Enable the iPerf info inside the speedtest block, set to false to disable;
 const LG_SPEEDTEST_IPERF = true;
 // Define the label of an incoming iPerf test;
 const LG_SPEEDTEST_LABEL_INCOMING = 'iPerf3 Incoming';
 // Define the command to use to test incoming speed using iPerf, preferable iPerf3;
-const LG_SPEEDTEST_CMD_INCOMING = 'iperf3 -4 -c hostname -p 5201 -P 4';
+const LG_SPEEDTEST_CMD_INCOMING = 'iperf3 -4 -c ' . LG_IPV4 . ' -p 5201 -P 4';
 // Define the label of an outgoing iPerf test;
 const LG_SPEEDTEST_LABEL_OUTGOING = 'iPerf3 Outgoing';
 // Define the command to use to test outgoing speed using iPerf, preferable iPerf3;
-const LG_SPEEDTEST_CMD_OUTGOING = 'iperf3 -4 -c hostname -p 5201 -P 4 -R';
+const LG_SPEEDTEST_CMD_OUTGOING = 'iperf3 -4 -c ' . LG_IPV4 . ' -p 5201 -P 4 -R';
 // Define speedtest files with URLs to the actual files;
-const LG_SPEEDTEST_FILES = [
+/* const LG_SPEEDTEST_FILES = [
     '100M' => 'https://github.com/hybula/lookingglass/',
     '1G' => 'https://github.com/hybula/lookingglass/',
     '10G' => 'https://github.com/hybula/lookingglass/'
-];
+]; */
+const LG_SPEEDTEST_FILES = [];
 
 // Define if you require visitors to agree with the Terms of Use. The value should be a link to the terms, or false to disable it completely.
 define('LG_TERMS', getenv('LG_TERMS') ?: false);

--- a/docker/php-fpm/src/config.php
+++ b/docker/php-fpm/src/config.php
@@ -75,11 +75,11 @@ const LG_SPEEDTEST_IPERF = true;
 // Define the label of an incoming iPerf test;
 const LG_SPEEDTEST_LABEL_INCOMING = 'iPerf3 Incoming';
 // Define the command to use to test incoming speed using iPerf, preferable iPerf3;
-const LG_SPEEDTEST_CMD_INCOMING = 'iperf3 -4 -c ' . LG_IPV4 . ' -p 5201 -P 4';
+const LG_SPEEDTEST_CMD_INCOMING = 'iperf3 -4 -c hostname -p 5201 -P 4';
 // Define the label of an outgoing iPerf test;
 const LG_SPEEDTEST_LABEL_OUTGOING = 'iPerf3 Outgoing';
 // Define the command to use to test outgoing speed using iPerf, preferable iPerf3;
-const LG_SPEEDTEST_CMD_OUTGOING = 'iperf3 -4 -c ' . LG_IPV4 . ' -p 5201 -P 4 -R';
+const LG_SPEEDTEST_CMD_OUTGOING = 'iperf3 -4 -c hostname -p 5201 -P 4 -R';
 // Define speedtest files with URLs to the actual files;
 /* const LG_SPEEDTEST_FILES = [
     '100M' => 'https://github.com/hybula/lookingglass/',

--- a/index.php
+++ b/index.php
@@ -130,7 +130,9 @@ $templateData['csrfToken'] = $_SESSION[LookingGlass::SESSION_CSRF] = bin2hex(ran
                 <select class="form-select" onchange="window.location = this.options[this.selectedIndex].value" <?php if (count($templateData['locations']) == 0) echo 'disabled'; ?>>
                     <option selected><?php echo $templateData['current_location'] ?></option>
                     <?php foreach ($templateData['locations'] as $location => $link): ?>
-                        <option value="<?php echo $link ?>"><?php echo $location ?></option>
+                        <?php if ($location !== $templateData['current_location']): ?>
+                            <option value="<?php echo $link ?>"><?php echo $location ?></option>
+                        <?php endif ?>
                     <?php endforeach ?>
                 </select>
             </div>
@@ -171,14 +173,14 @@ $templateData['csrfToken'] = $_SESSION[LookingGlass::SESSION_CSRF] = bin2hex(ran
 
                     <div class="row mb-3">
                         <div class="col-md-3">
-                            <label class="mb-2 text-muted">Test IPv4</label>
+                            <label class="mb-2 text-muted">Looking Glass IPv4</label>
                             <div class="input-group">
                                 <input type="text" class="form-control" value="<?php echo $templateData['ipv4'] ?>" onfocus="this.select()" readonly="">
                                 <button class="btn btn-outline-secondary" onclick="copyToClipboard('<?php echo $templateData['ipv4'] ?>', this)">Copy</button>
                             </div>
                         </div>
                         <div class="col-md-5">
-                            <label class="mb-2 text-muted">Test IPv6</label>
+                            <label class="mb-2 text-muted">Looking Glass IPv6</label>
                             <div class="input-group">
                                 <input type="text" class="form-control" value="<?php echo $templateData['ipv6'] ?>" onfocus="this.select()" readonly="">
                                 <button class="btn btn-outline-secondary" onclick="copyToClipboard('<?php echo $templateData['ipv6'] ?>', this)">Copy</button>
@@ -272,7 +274,7 @@ $templateData['csrfToken'] = $_SESSION[LookingGlass::SESSION_CSRF] = bin2hex(ran
                     </div>
                     <?php endif ?>
     
-					<?php if (count($templateData['speedtest_files'])): ?>
+                    <?php if (count($templateData['speedtest_files'])): ?>
                     <div class="row">
                         <label class="mb-2 text-muted">Test Files</label>
                         <div class="btn-group input-group mb-3">
@@ -281,7 +283,7 @@ $templateData['csrfToken'] = $_SESSION[LookingGlass::SESSION_CSRF] = bin2hex(ran
                             <?php endforeach ?>
                         </div>
                     </div>
-					<?php endif ?>
+                    <?php endif ?>
 
                 </div>
             </div>


### PR DESCRIPTION
1. Docker Fixes
- Add iPerf3 container.
- Make containers' build paths consistent.
- Fix latency detection not working under Docker environments:
> This feature relies on `ss` which did not work when using Docker due to missing `iproute2` package in `php-fpm` Docker image and incorrect network mode for the containers. `ss` relies on socket descriptors which do not exist in containers unless using `host` network mode. Plus, `host` network mode improves network performance when using Docker, especially beneficial to iPerf3 container.

2. Minor PHP Code Improvements
- When `LG_LOCATIONS` contains the current location, which in my opinion is expected when deploying in multiple locations. The location drop-down menu displays the same location twice due to `$templateData['current_location']` and `$templateData['locations']` both being displayed. An `if` check is implemented to deduplicate.
- Default values for certain constants are changed to empty arrays to trigger auto-hiding by default. The previous placeholder values are kept in comments for users' reference.
- Change "Test IPv4" and "Test IPv6" to "Looking Glass IPv4" and "Looking Glass IPv4", respectively, which in my opinion, is less ambiguous.
- iPerf3 block now uses `LG_IPV4` to display the IP address of the looking glass, instead of being set manually.

3. Documentation
- Add iPerf3-related instructions for manual installation.

There might also be some other small changes I failed to mention. Thank you for reading this.