### PR TITLE
Docker images vulnerable (CVE-2024-4577)

### DIFF
--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-bullseye
+FROM php:8.4.1-fpm-bullseye
 
 RUN apt-get update && \
     apt-get --no-install-recommends -y install iputils-ping mtr traceroute iproute2 && \


### PR DESCRIPTION
It seems like the used Docker image for the php-fpm container is vulnerable to (at least) CVE-2024-4577 (https://nvd.nist.gov/vuln/detail/cve-2024-4577) which allows attackers to execute custom scripts remotely.

Therefore I highly recommend to update the used base image from php:8.1-fpm-bullseye to e.g. php:8.4.1-fpm-bullseye.