### PR TITLE
Fix TypeError when accessing via domain in Docker

### DIFF
--- a/LookingGlass.php
+++ b/LookingGlass.php
@@ -453,7 +453,7 @@ class LookingGlass
         $ss = [];
         $i = 0;
         $j = 0;
-        foreach (explode(PHP_EOL, $lines) as $line) {
+        foreach (explode(PHP_EOL, $lines ?? '') as $line) {
             if ($i > 1) {
                 $i = 0;
                 $j++;


### PR DESCRIPTION
- Add null coalescing operator to handle null return from shell_exec()
- Prevents fatal error when ss command finds no established connections
- Common in Docker environments with reverse proxy/domain access